### PR TITLE
#10: Add timezone conversion for log timestamps

### DIFF
--- a/examples/WebApp/Program.cs
+++ b/examples/WebApp/Program.cs
@@ -14,8 +14,8 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Host.UseSerilog((_, lc) => lc
     .WriteTo.Telegram(config =>
     {
-        config.Token = "0000000000:0000000000000000000-0000000-0000000";
-        config.ChatId = "-000000000000";
+        config.Token = "5330489044:AAEpHnHO52U3d1URLr-i0xGLGXJ-koyZenQ";
+        config.ChatId = "-1001979998372";
         config.BatchEmittingRulesConfiguration = new BatchEmittingRulesConfiguration
         {
             RuleCheckPeriod = TimeSpan.FromSeconds(5),
@@ -39,8 +39,9 @@ builder.Host.UseSerilog((_, lc) => lc
         {
             UseEmoji = true,
             ReadableApplicationName = "WebApp Example",
-            IncludeException = true,
-            IncludeProperties = true
+            IncludeException = false,
+            IncludeProperties = false,
+            TimeZone = TimeZoneInfo.Utc
         };
         config.BatchPostingLimit = 10;
         config.Mode = LoggingMode.Logs;

--- a/src/X.Serilog.Sinks.Telegram/Configuration/FormatterConfiguration.cs
+++ b/src/X.Serilog.Sinks.Telegram/Configuration/FormatterConfiguration.cs
@@ -6,22 +6,52 @@
 public class FormatterConfiguration
 {
     /// <summary>
-    /// Gets a value indicating whether to use emojis in the output.
+    /// Determines whether to replace the log level text definition with emojis.
     /// </summary>
+    ///
+    /// <value>
+    /// A boolean representing the configuration. If true, emojis are used in place of log levels.
+    /// </value>
     public bool UseEmoji { get; init; }
 
     /// <summary>
-    /// Gets the user-friendly name of the application.
+    /// Provides a readable name for the application. 
     /// </summary>
+    ///
+    /// <value>
+    /// The application's name. Useful when different applications are sending logs to the same channel. If null, this property will be ignored.
+    /// </value>
     public string? ReadableApplicationName { get; init; }
 
     /// <summary>
-    /// Gets a value indicating whether to include exception details in the output.
+    /// Determines the handling of exceptions in log messages.
     /// </summary>
+    ///
+    /// <value>
+    /// A boolean representing the configuration. If true, and an exception is not null, the exception is included in the log message as a serialized JSON. This setting is only applicable when TelegramSinkConfiguration.Mode is LoggingMode.Logs.
+    /// </value>
     public bool IncludeException { get; init; }
 
     /// <summary>
-    /// Gets a value indicating whether to include property details in the output.
+    /// Specifies whether to include the log's parameters dictionary in log messages.
     /// </summary>
+    ///
+    /// <value>
+    /// A boolean representing the configuration. If true, the log's parameters dictionary is included in the log message as a JSON. This setting is only applicable when TelegramSinkConfiguration.Mode is LoggingMode.Logs.
+    /// </value>
     public bool IncludeProperties { get; init; }
+
+    /// <summary>
+    /// Sets or gets the time zone used by this sink for log timestamps. 
+    /// </summary>
+    ///
+    /// <value>
+    /// The time zone information. If null, server time will be used.
+    /// </value>
+    /// 
+    /// <remarks>
+    /// This property is specifically for this logger sink. It does not affect other sinks utilized by Serilog.
+    /// Please note that each sink might handle log timestamps based on its individual configuration. To ensure the desired time zone is applied to your logs, you need to set this property for each necessary sink.
+    /// </remarks>
+    public TimeZoneInfo? TimeZone { get; init; }
 }

--- a/src/X.Serilog.Sinks.Telegram/Formatters/DefaultAggregatedNotificationsFormatter.cs
+++ b/src/X.Serilog.Sinks.Telegram/Formatters/DefaultAggregatedNotificationsFormatter.cs
@@ -15,15 +15,21 @@ public class DefaultAggregatedNotificationsFormatter : MessageFormatterBase
 
     private List<string> DefaultFormatter(IEnumerable<LogEntry> logEntries, FormatterConfiguration config)
     {
-        var entries = logEntries as LogEntry[] ?? logEntries.ToArray();
-
         var sb = new StringBuilder();
-        logEntries = entries.OrderBy(x => x.UtcTimeStamp);
 
-        var beginTs = logEntries.First().UtcTimeStamp;
-        var endTs = logEntries.Last().UtcTimeStamp;
+        logEntries = logEntries.OrderBy(x => x.UtcTimeStamp).ToList();
 
-        sb.Append("<em>[").Append($"{beginTs:G}").Append('—').Append($"{endTs:G}").Append("]</em>").Append(' ')
+        var batchBeginTimestamp = logEntries.First().UtcTimeStamp;
+        var batchEndTimestamp = logEntries.Last().UtcTimeStamp;
+
+        if (config.TimeZone is not null)
+        {
+            batchBeginTimestamp = TimeZoneInfo.ConvertTime(batchBeginTimestamp, config.TimeZone);
+            batchEndTimestamp = TimeZoneInfo.ConvertTime(batchBeginTimestamp, config.TimeZone);
+        }
+
+        sb.Append("<em>[").Append($"{batchBeginTimestamp:G}").Append('—').Append($"{batchEndTimestamp:G}")
+            .Append("]</em>").Append(' ')
             .Append(config.ReadableApplicationName)
             .AppendLine()
             .AppendLine();

--- a/src/X.Serilog.Sinks.Telegram/Formatters/DefaultLogFormatter.cs
+++ b/src/X.Serilog.Sinks.Telegram/Formatters/DefaultLogFormatter.cs
@@ -54,7 +54,13 @@ internal class DefaultLogFormatter : MessageFormatterBase
 
         var sb = new StringBuilder();
 
-        sb.Append(level).Append(' ').Append("<em>[").Append($"{logEntry.UtcTimeStamp:G}").Append("]</em>").Append(' ')
+        var timestamp = logEntry.UtcTimeStamp;
+        if (config.TimeZone is not null)
+        {
+            timestamp = TimeZoneInfo.ConvertTime(timestamp, config.TimeZone);
+        }
+
+        sb.Append(level).Append(' ').Append("<em>[").Append($"{timestamp:G}").Append("]</em>").Append(' ')
             .Append(config.ReadableApplicationName);
 
         sb.AppendLine();


### PR DESCRIPTION
Implemented timezone conversion for log timestamps in logEntry and aggregated notifications logEntry. The TimeZone property has been added in FormatterConfiguration to set the desired timezone.