### PR TITLE
Quickstart configuration

### DIFF
--- a/X.Serilog.Sinks.Telegram.sln
+++ b/X.Serilog.Sinks.Telegram.sln
@@ -8,6 +8,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "examples", "examples", "{4A
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApp", "examples\WebApp\WebApp.csproj", "{15736D36-94A1-4E3F-8A5F-EFEFE27F1995}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleApp", "examples\ConsoleApp\ConsoleApp.csproj", "{D007F793-195D-448A-A34E-74EF0245F9D3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -22,9 +24,14 @@ Global
 		{15736D36-94A1-4E3F-8A5F-EFEFE27F1995}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{15736D36-94A1-4E3F-8A5F-EFEFE27F1995}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{15736D36-94A1-4E3F-8A5F-EFEFE27F1995}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D007F793-195D-448A-A34E-74EF0245F9D3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D007F793-195D-448A-A34E-74EF0245F9D3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D007F793-195D-448A-A34E-74EF0245F9D3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D007F793-195D-448A-A34E-74EF0245F9D3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{807F309C-4CE3-4E68-8D46-9044A0A7BD6A} = {652C6F31-3E8C-400E-9716-ACF591E48E6F}
 		{15736D36-94A1-4E3F-8A5F-EFEFE27F1995} = {4A2DA76C-10DE-476D-A26E-16FAB3CBFC8C}
+		{D007F793-195D-448A-A34E-74EF0245F9D3} = {4A2DA76C-10DE-476D-A26E-16FAB3CBFC8C}
 	EndGlobalSection
 EndGlobal

--- a/examples/ConsoleApp/ConsoleApp.csproj
+++ b/examples/ConsoleApp/ConsoleApp.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Serilog" Version="3.1.1" />
+      <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\X.Serilog.Sinks.Telegram\X.Serilog.Sinks.Telegram.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/examples/ConsoleApp/Program.cs
+++ b/examples/ConsoleApp/Program.cs
@@ -1,0 +1,23 @@
+﻿using Serilog;
+using Serilog.Events;
+using X.Serilog.Sinks.Telegram.Extensions;
+
+const string botToken = "TELEGRAM_BOT_TOKEN";
+const string loggingChatId = "CHANNEL_OR_CHAT_ID";
+
+Log.Logger = new LoggerConfiguration()
+    // add console as logging target
+    .WriteTo.TelegramCore(
+        token: botToken,
+        chatId: loggingChatId,
+        logLevel: LogEventLevel.Verbose)
+    .WriteTo.Console()
+    .CreateLogger();
+
+
+while (true)
+{
+    var level = Random.Shared.NextInt64(0, 6);
+    Log.Logger.Write((LogEventLevel)level, "Message");
+    await Task.Delay(500);
+}

--- a/examples/ConsoleApp/Program.cs
+++ b/examples/ConsoleApp/Program.cs
@@ -6,7 +6,6 @@ const string botToken = "TELEGRAM_BOT_TOKEN";
 const string loggingChatId = "CHANNEL_OR_CHAT_ID";
 
 Log.Logger = new LoggerConfiguration()
-    // add console as logging target
     .WriteTo.TelegramCore(
         token: botToken,
         chatId: loggingChatId,

--- a/examples/WebApp/Program.cs
+++ b/examples/WebApp/Program.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using X.Serilog.Sinks.Telegram;
 using X.Serilog.Sinks.Telegram.Batch.Rules;
 using X.Serilog.Sinks.Telegram.Configuration;
+using X.Serilog.Sinks.Telegram.Extensions;
 using X.Serilog.Sinks.Telegram.Filters;
 
 var builder = WebApplication.CreateBuilder(args);

--- a/examples/WebApp/WebApp.csproj
+++ b/examples/WebApp/WebApp.csproj
@@ -7,8 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Serilog.AspNetCore" Version="7.0.0"/>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+        <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
+        <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     </ItemGroup>
 
 

--- a/src/X.Serilog.Sinks.Telegram/Configuration/BatchEmittingRulesConfiguration.cs
+++ b/src/X.Serilog.Sinks.Telegram/Configuration/BatchEmittingRulesConfiguration.cs
@@ -40,15 +40,7 @@ public class BatchEmittingRulesConfiguration
     /// </summary>
     public IImmutableList<IExecutionHook> BatchProcessingExecutionHooks
         => BatchProcessingRules
-            .Select(rule =>
-            {
-                if (rule is IExecutionHook hook)
-                {
-                    return hook;
-                }
-
-                return null;
-            })
-            .Where(hook => hook != null)
-            .ToImmutableList()!;
+            .Where(rule => rule is IExecutionHook)
+            .Cast<IExecutionHook>()
+            .ToImmutableList();
 }

--- a/src/X.Serilog.Sinks.Telegram/Configuration/TelegramSinkDefaults.cs
+++ b/src/X.Serilog.Sinks.Telegram/Configuration/TelegramSinkDefaults.cs
@@ -22,7 +22,7 @@ public static class TelegramSinkDefaults
     /// Other modes, like <see cref="LoggingMode.AggregatedNotifications"/>, could aggregate messages over a period 
     /// or until a certain condition is met before sending.
     /// </remarks>
-    public static LoggingMode DefaultFormatterMode => LoggingMode.Logs;
+    public static LoggingMode DefaultFormatterMode => LoggingMode.AggregatedNotifications;
 
     public static FormatterConfiguration DefaultFormatterConfiguration => new()
     {

--- a/src/X.Serilog.Sinks.Telegram/Configuration/TelegramSinkDefaults.cs
+++ b/src/X.Serilog.Sinks.Telegram/Configuration/TelegramSinkDefaults.cs
@@ -8,6 +8,32 @@ namespace X.Serilog.Sinks.Telegram.Configuration;
 public static class TelegramSinkDefaults
 {
     /// <summary>
+    /// Gets the logging mode for the application.
+    /// </summary>
+    /// <value>
+    /// The logging mode determines how log messages are processed and formatted before being sent. 
+    /// In this case, it is set to return <see cref="LoggingMode.Logs"/>, which indicates that log messages 
+    /// will be published individually to the specified Telegram channel.
+    /// </value>
+    /// <remarks>
+    /// This property is read-only and returns the default logging mode of the system. 
+    /// It is crucial for configuring the overall logging strategy of the application. 
+    /// For example, when set to <see cref="LoggingMode.Logs"/>, each log message is sent as it occurs. 
+    /// Other modes, like <see cref="LoggingMode.AggregatedNotifications"/>, could aggregate messages over a period 
+    /// or until a certain condition is met before sending.
+    /// </remarks>
+    public static LoggingMode DefaultFormatterMode => LoggingMode.Logs;
+
+    public static FormatterConfiguration DefaultFormatterConfiguration => new()
+    {
+        UseEmoji = true,
+        ReadableApplicationName = "X.Serilog.Telegram.Sink",
+        IncludeException = false,
+        IncludeProperties = false,
+        TimeZone = TimeZoneInfo.Utc
+    };
+
+    /// <summary>
     /// The limit on the number of log events to be included in a single batch.
     /// </summary>
     public const int BatchPostingLimit = 20;

--- a/src/X.Serilog.Sinks.Telegram/Extensions/DependencyInjectionExtensions.cs
+++ b/src/X.Serilog.Sinks.Telegram/Extensions/DependencyInjectionExtensions.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Immutable;
+using X.Serilog.Sinks.Telegram.Batch.Rules;
+using X.Serilog.Sinks.Telegram.Configuration;
+
+namespace X.Serilog.Sinks.Telegram.Extensions;
+
+public static class DependencyInjectionExtensions
+{
+    public static LoggerSinkConfiguration TelegramCore(
+        this LoggerSinkConfiguration sinkConfig,
+        string token,
+        string chatId,
+        LogEventLevel logLevel
+    )
+    {
+        ArgumentNullException.ThrowIfNull(sinkConfig);
+        ArgumentNullException.ThrowIfNull(token);
+        ArgumentNullException.ThrowIfNull(chatId);
+
+        TelegramCoreInternal(sinkConfig, token, chatId, logLevel);
+
+        return sinkConfig;
+    }
+
+    private static void TelegramCoreInternal(LoggerSinkConfiguration sinkConfig, string token, string chatId,
+        LogEventLevel logLevel)
+    {
+        sinkConfig.Telegram(config =>
+            {
+                config.Token = token;
+                config.ChatId = chatId;
+
+                config.Mode = TelegramSinkDefaults.DefaultFormatterMode;
+
+                config.BatchPostingLimit = TelegramSinkDefaults.BatchPostingLimit;
+                config.BatchEmittingRulesConfiguration = new BatchEmittingRulesConfiguration
+                {
+                    RuleCheckPeriod = TelegramSinkDefaults.RulesCheckPeriod,
+                    BatchProcessingRules = new ImmutableArray<IRule>
+                    {
+                        // send logs to the Telegram once per 250 seconds
+                        new OncePerTimeRule(TelegramSinkDefaults.RulesCheckPeriod * 50)
+                    }
+                };
+                config.FormatterConfiguration = TelegramSinkDefaults.DefaultFormatterConfiguration;
+            },
+            messageFormatter: null!,
+            restrictedToMinimumLevel: logLevel);
+    }
+}

--- a/src/X.Serilog.Sinks.Telegram/Extensions/DependencyInjectionExtensions.cs
+++ b/src/X.Serilog.Sinks.Telegram/Extensions/DependencyInjectionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Immutable;
 using X.Serilog.Sinks.Telegram.Batch.Rules;
 using X.Serilog.Sinks.Telegram.Configuration;
+using X.Serilog.Sinks.Telegram.Filters;
 
 namespace X.Serilog.Sinks.Telegram.Extensions;
 
@@ -22,7 +23,10 @@ public static class DependencyInjectionExtensions
         return sinkConfig;
     }
 
-    private static void TelegramCoreInternal(LoggerSinkConfiguration sinkConfig, string token, string chatId,
+    private static void TelegramCoreInternal(
+        LoggerSinkConfiguration sinkConfig,
+        string token,
+        string chatId,
         LogEventLevel logLevel)
     {
         sinkConfig.Telegram(config =>
@@ -43,6 +47,11 @@ public static class DependencyInjectionExtensions
                     }
                 };
                 config.FormatterConfiguration = TelegramSinkDefaults.DefaultFormatterConfiguration;
+                config.LogFiltersConfiguration = new LogsFiltersConfiguration()
+                {
+                    ApplyLogFilters = false,
+                    Filters = new ImmutableArray<IFilter>()
+                };
             },
             messageFormatter: null!,
             restrictedToMinimumLevel: logLevel);

--- a/src/X.Serilog.Sinks.Telegram/Extensions/LoggerConfigurationTelegramExtensions.cs
+++ b/src/X.Serilog.Sinks.Telegram/Extensions/LoggerConfigurationTelegramExtensions.cs
@@ -1,8 +1,9 @@
 ﻿using System.Threading.Channels;
 using X.Serilog.Sinks.Telegram.Batch;
+using X.Serilog.Sinks.Telegram.Configuration;
 using X.Serilog.Sinks.Telegram.Formatters;
 
-namespace X.Serilog.Sinks.Telegram.Configuration;
+namespace X.Serilog.Sinks.Telegram.Extensions;
 
 public static class LoggerConfigurationTelegramExtensions
 {

--- a/src/X.Serilog.Sinks.Telegram/Formatters/DefaultAggregatedNotificationsFormatter.cs
+++ b/src/X.Serilog.Sinks.Telegram/Formatters/DefaultAggregatedNotificationsFormatter.cs
@@ -7,7 +7,7 @@ public class DefaultAggregatedNotificationsFormatter : MessageFormatterBase
     public override List<string> Format(
         ICollection<LogEntry> logEntries,
         FormatterConfiguration config,
-        Func<ICollection<LogEntry>, FormatterConfiguration, List<string>> formatter = null)
+        Func<ICollection<LogEntry>, FormatterConfiguration, List<string>>? formatter = null)
     {
         formatter ??= DefaultFormatter;
         return base.Format(logEntries, config, formatter);

--- a/src/X.Serilog.Sinks.Telegram/Formatters/DefaultLogFormatter.cs
+++ b/src/X.Serilog.Sinks.Telegram/Formatters/DefaultLogFormatter.cs
@@ -9,7 +9,7 @@ internal class DefaultLogFormatter : MessageFormatterBase
     /// <exception cref="ArgumentException">Throws when, after using the formatter, the message is null, empty, or whitespace.</exception>
     public override List<string> Format(ICollection<LogEntry> logEntries,
         FormatterConfiguration config,
-        Func<ICollection<LogEntry>, FormatterConfiguration, List<string>> formatter = null)
+        Func<ICollection<LogEntry>, FormatterConfiguration, List<string>>? formatter = null)
     {
         if (!NotEmpty(logEntries))
         {

--- a/src/X.Serilog.Sinks.Telegram/Formatters/IMessageFormatter.cs
+++ b/src/X.Serilog.Sinks.Telegram/Formatters/IMessageFormatter.cs
@@ -13,5 +13,5 @@ public interface IMessageFormatter
     /// <returns>Human-readable message.</returns>
     List<string> Format(ICollection<LogEntry> logEntries,
         FormatterConfiguration config,
-        Func<ICollection<LogEntry>, FormatterConfiguration, List<string>> formatter = null);
+        Func<ICollection<LogEntry>, FormatterConfiguration, List<string>>? formatter = null);
 }

--- a/src/X.Serilog.Sinks.Telegram/Formatters/MessageFormatterBase.cs
+++ b/src/X.Serilog.Sinks.Telegram/Formatters/MessageFormatterBase.cs
@@ -10,7 +10,7 @@ public abstract class MessageFormatterBase : IMessageFormatter
     /// <inheritdoc />
     public virtual List<string> Format(ICollection<LogEntry> logEntries,
         FormatterConfiguration config,
-        Func<ICollection<LogEntry>, FormatterConfiguration, List<string>> formatter = null)
+        Func<ICollection<LogEntry>, FormatterConfiguration, List<string>>? formatter = null)
     {
         if (!NotEmpty(logEntries))
         {

--- a/src/X.Serilog.Sinks.Telegram/TelegramSink.cs
+++ b/src/X.Serilog.Sinks.Telegram/TelegramSink.cs
@@ -112,7 +112,8 @@ public class TelegramSink : ILogEventSink, IDisposable, IAsyncDisposable
     private async Task<IImmutableList<string>> GetMessagesFromQueueAsync(int amount)
     {
         var logsBatch = await _logsQueueAccessor.DequeueSeveralAsync(amount);
-        var events = logsBatch.Where(log => log is not null)
+        var events = logsBatch
+            .Where(log => log is not null)
             .Select(LogEntry.MapFrom)
             .ToList();
 

--- a/src/X.Serilog.Sinks.Telegram/X.Serilog.Sinks.Telegram.csproj
+++ b/src/X.Serilog.Sinks.Telegram/X.Serilog.Sinks.Telegram.csproj
@@ -15,7 +15,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Serilog" Version="3.0.1"/>
+        <PackageReference Include="Serilog" Version="3.1.1" />
         <PackageReference Include="Telegram.Bot" Version="19.0.0"/>
     </ItemGroup>
 


### PR DESCRIPTION
This PR introduces an extension method that allows you to start using Telegram for logging with a single method call with only two params: `telegram_bot_token` and `channel_or_chat_id`.

```cs
const string botToken = "TELEGRAM_BOT_TOKEN";
const string loggingChatId = "CHANNEL_OR_CHAT_ID";

Log.Logger = new LoggerConfiguration()
    .WriteTo.TelegramCore(
        token: botToken,
        chatId: loggingChatId,
        logLevel: LogEventLevel.Verbose)
    .CreateLogger();


while (true)
{
    var level = Random.Shared.NextInt64(0, 6);
    Log.Logger.Write((LogEventLevel)level, "Message");
    await Task.Delay(500);
}
```