### PR TITLE
Remove docs folder

### DIFF
--- a/docs/configuration-options-descriptions.md
+++ b/docs/configuration-options-descriptions.md
@@ -1,6 +1,0 @@
-﻿
-### Events representing modes
-Now supported 3 modes of message formatting: logs, notifications and aggregated notifications.
-- Logs — Represents a common log message with a great amount of additional information.
-- Notifications — Represents a short message without any details.
-- Aggregated notifications —  Represents a bench of short messages without any details.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,4 +1,0 @@
-﻿# X.Serilog.Sinks.Telegram's roadmap
-
-To be done...
-


### PR DESCRIPTION
Docs now located at the GitHub repo's wiki